### PR TITLE
perf: switch from `minimatch` to `picomatch`

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "typecheck:src": "tsc -p ./src/tsconfig.json --noEmit"
   },
   "dependencies": {
-    "minimatch": "^9.0.5"
+    "picomatch": "^4.0.2"
   },
   "devDependencies": {
     "@commitlint/cli": "19.8.0",
@@ -88,6 +88,7 @@
     "@semantic-release/release-notes-generator": "14.0.3",
     "@stylistic/eslint-plugin": "4.2.0",
     "@types/node": "22.13.10",
+    "@types/picomatch": "^3.0.2",
     "@typescript-eslint/eslint-plugin": "8.26.0",
     "@typescript-eslint/parser": "8.26.0",
     "@vitest/coverage-v8": "3.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,9 @@ importers:
 
   .:
     dependencies:
-      minimatch:
-        specifier: ^9.0.5
-        version: 9.0.5
+      picomatch:
+        specifier: ^4.0.2
+        version: 4.0.2
     devDependencies:
       '@commitlint/cli':
         specifier: 19.8.0
@@ -57,6 +57,9 @@ importers:
       '@types/node':
         specifier: 22.13.10
         version: 22.13.10
+      '@types/picomatch':
+        specifier: ^3.0.2
+        version: 3.0.2
       '@typescript-eslint/eslint-plugin':
         specifier: 8.26.0
         version: 8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2)
@@ -1245,6 +1248,9 @@ packages:
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
+
+  '@types/picomatch@3.0.2':
+    resolution: {integrity: sha512-n0i8TD3UDB7paoMMxA3Y65vUncFJXjcUf7lQY7YyKGl6031FNjfsLs6pdLFCy2GNFxItPJG8GvvpbZc2skH7WA==}
 
   '@types/semver@7.5.8':
     resolution: {integrity: sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==}
@@ -5655,6 +5661,8 @@ snapshots:
       undici-types: 6.20.0
 
   '@types/normalize-package-data@2.4.4': {}
+
+  '@types/picomatch@3.0.2': {}
 
   '@types/semver@7.5.8': {}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import * as path from "node:path";
 
-import { minimatch } from "minimatch";
+import pm from "picomatch";
 import ts from "typescript";
 
 import type { TypeDeclarationSpecifier } from "./types.ts";
@@ -141,7 +141,7 @@ function isTypeDeclaredInLocalFile(
     const canonicalPath = getCanonicalFilePath(declaration.path);
     return (
       canonicalPath.startsWith(cwd) &&
-      (minimatch(canonicalPath, globPattern) || minimatch(`./${path.relative(cwd, canonicalPath)}`, globPattern))
+      (pm.isMatch(canonicalPath, globPattern) || pm.isMatch(`./${path.relative(cwd, canonicalPath)}`, globPattern))
     );
   });
 }


### PR DESCRIPTION
Switches from `minimatch` to `picomatch` (0 dependencies).

The library should support almost every glob syntax previously supported, with the exception of some far edge case range patterns, and has been adopted by `fdir` and [`rollup`](https://github.com/rollup/plugins/blob/e1a5ef99f1578eb38a8c87563cb9651db228f3bd/packages/pluginutils/src/createFilter.ts#L3).